### PR TITLE
Fix class binder array reference

### DIFF
--- a/src/binders/class.ts
+++ b/src/binders/class.ts
@@ -51,7 +51,7 @@ const binder: Binder<BinderContext> = {
       }
 
       // save current status
-      this.classes = newClasses;
+      this.classes = [...newClasses];
     }
   },
 


### PR DESCRIPTION
Hi! We found a problem when the argument is not provided to the class binder and the value is an array.
When I modify the binded value the element doesn't get updated because the array is assigned by reference to `this.classes` (you can see it in lines 34 and 54).
So when you push something new to the value array, `oldClasses` is already the binded array (line 27).